### PR TITLE
fix bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ This module is a special plug-in for the rich text editor `vue-quill-editor`, wh
   
     1. 没更新什么，就是想发个大版本玩玩 Nothing updated, just want to send a big version for fun
 
+-   Version 2.0.1
+  
+    1. 解决当复制多行文本且文本中有回车时，会出现多余空白行的 `bug` Solve the `bug` that extra blank lines will appear when copying multiple lines of text and there is a carriage return in the text
+
 ## 安装 installation
 
 ```shell

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ export class ImageExtend {
                     const self = QuillWatch.active;
                     let length = self.quill.getSelection(true).index;
                     self.cursorIndex = length;
-                    self.quill.insertText(QuillWatch.active.cursorIndex, s);
+                    self.quill.insertText(QuillWatch.active.cursorIndex, s.replace(/\s{2,}/g, "\n"));
                     self.quill.update();
                     setTimeout(() => self.quill.setSelection(self.cursorIndex + s.length, 0), 0);
                 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "quill-image-super-solution-module",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "The ultimate solution. Image upload server. Copy, drag and drop to upload server.",
     "main": "index.js",
     "scripts": {
@@ -9,16 +9,7 @@
     "repository": {
         "url": "https://github.com/EthanYan6/quill-image-super-solution-module"
     },
-    "keywords": [
-        "vue",
-        "editor",
-        "quill",
-        "image",
-        "uploads",
-        "extend",
-        "paste",
-        "drop"
-    ],
+    "keywords": ["vue", "editor", "quill", "image", "uploads", "extend", "paste", "drop"],
     "author": "ethanyan",
     "license": "MIT",
     "bugs": {


### PR DESCRIPTION
Solve the `bug` that extra blank lines will appear when copying multiple lines of text and there is a carriage return in the text