### PR TITLE
fix: Insert and drag image always in beginning

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,6 +156,8 @@ export class ImageExtend {
         const self = this;
         let quillLoading = self.quillLoading;
         let config = self.config;
+        // 插入图片前，更新光标位置
+        self.cursorIndex = self.quill.getSelection(true).index;
         // 构造表单
         let formData = new FormData();
         formData.append(config.name, self.file);
@@ -180,8 +182,6 @@ export class ImageExtend {
                     let res = JSON.parse(xhr.responseText);
                     self.imgURL = config.response(res);
                     QuillWatch.active.uploadSuccess();
-                    // 插入图片前，更新光标位置
-                    self.cursorIndex = self.quill.getSelection(true).index
                     self.insertImg();
                     if (self.config.success) {
                         self.config.success();

--- a/index.js
+++ b/index.js
@@ -180,6 +180,8 @@ export class ImageExtend {
                     let res = JSON.parse(xhr.responseText);
                     self.imgURL = config.response(res);
                     QuillWatch.active.uploadSuccess();
+                    // 插入图片前，更新光标位置
+                    self.cursorIndex = self.quill.getSelection(true).index
                     self.insertImg();
                     if (self.config.success) {
                         self.config.success();


### PR DESCRIPTION
The problem arises when you type in some text and then insert or drag a picture. The pr can fix the following issue.
[https://github.com/EthanYan6/quill-image-super-solution-module/issues/11](url)
[https://github.com/EthanYan6/quill-image-super-solution-module/issues/8](url)
[https://github.com/EthanYan6/quill-image-super-solution-module/issues/6](url)